### PR TITLE
Fix for highlighting typeahead with arrow keys

### DIFF
--- a/typeaheadjs.css
+++ b/typeaheadjs.css
@@ -35,7 +35,10 @@ span.twitter-typeahead .tt-suggestion > p:focus {
   outline: 0;
   background-color: #428bca;
 }
-
+span.twitter-typeahead .tt-suggestion.tt-cursor {
+  color: #ffffff;
+  background-color: #428bca;
+}
 span.twitter-typeahead {
   width: 100%;
 }


### PR DESCRIPTION
the current version highlights typeaheads only when mouseover.  this
version highlights even with arrow keys.
