### PR TITLE
Remove `> p`

### DIFF
--- a/typeaheadjs.less
+++ b/typeaheadjs.less
@@ -9,7 +9,7 @@ width: 100%;
 &:extend(.dropdown-menu);
 }
 
-.tt-suggestion > p {
+.tt-suggestion {
   &:extend(.dropdown-menu > li > a);
   &:hover,
   &:focus {
@@ -17,7 +17,7 @@ width: 100%;
   }
 }
 
-.tt-suggestion.tt-cursor > p {
+.tt-suggestion.tt-cursor {
     &:extend(.dropdown-menu > .active > a);
 }
 


### PR DESCRIPTION
For Bootstrap 3.3.5 and Typeahead 0.11.1, there is no `<p>` element in .tt-suggestion by default.