### PR TITLE
Consistent use of indentation: 2 spaces whitespace

### DIFF
--- a/typeaheadjs.less
+++ b/typeaheadjs.less
@@ -1,8 +1,3 @@
-// bootstrap typeahead, simpler css,
-//
-// Note that :extend() will inject rules into standard twbs/bootstrap – clever!
-//
-// https://github.com/bassjobsen/typeahead.js-bootstrap-css/tree/a8a9d4339130b1133b63fef87faf895672849a26
 span.twitter-typeahead {
   width: 100%;
 

--- a/typeaheadjs.less
+++ b/typeaheadjs.less
@@ -1,40 +1,45 @@
+// bootstrap typeahead, simpler css,
+//
+// Note that :extend() will inject rules into standard twbs/bootstrap – clever!
+//
+// https://github.com/bassjobsen/typeahead.js-bootstrap-css/tree/a8a9d4339130b1133b63fef87faf895672849a26
 span.twitter-typeahead {
-width: 100%;
+  width: 100%;
 
-.tt-menu {
-&:extend(.dropdown-menu);
-}
-
-.tt-dropdown-menu {
-&:extend(.dropdown-menu);
-}
-
-.tt-suggestion {
-  &:extend(.dropdown-menu > li > a);
-  &:hover,
-  &:focus {
-	&:extend(.dropdown-menu > .active > a);
+  .tt-menu {
+    &:extend(.dropdown-menu);
   }
-}
 
-.tt-suggestion.tt-cursor {
+  .tt-dropdown-menu {
+    &:extend(.dropdown-menu);
+  }
+
+  .tt-suggestion {
+    &:extend(.dropdown-menu > li > a);
+    &:hover,
+    &:focus {
+      &:extend(.dropdown-menu > .active > a);
+    }
+  }
+
+  .tt-suggestion.tt-cursor {
     &:extend(.dropdown-menu > .active > a);
-}
+  }
 
-.input-group & {
-display: block !important;
+  .input-group & {
+    display: block !important;
     .tt-dropdown-menu {
-		top:32px !important;
-	}
-}
-.input-group.input-group-lg & {
-.tt-dropdown-menu {
-		top:44px !important;
-	}
-}
-.input-group.input-group-sm & {
-.tt-dropdown-menu {
-		top:28px !important;
-	}
-}
+      top:32px !important;
+    }
+  }
+  .input-group.input-group-lg & {
+    .tt-dropdown-menu {
+      top:44px !important;
+    }
+  }
+  .input-group.input-group-sm & {
+    .tt-dropdown-menu {
+      top:28px !important;
+    }
+  }
 }


### PR DESCRIPTION
The lack and inconsistency of indentation confused me. I suggest to stick with 2 spaces for indentation (this is what typeahead.js and twbs/bootstrap also are using).