### PR TITLE
Add examples with use of input-group

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<ol>
+    <li><a href="simple.html">Simple examples</a></li>
+    <li><a href="input-group.html">InputGroup examples</a></li>
+</ol>
+</body>
+</html>

--- a/examples/initialize.js
+++ b/examples/initialize.js
@@ -1,0 +1,46 @@
+var states = ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California',
+    'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii',
+    'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana',
+    'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota',
+    'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire',
+    'New Jersey', 'New Mexico', 'New York', 'North Carolina', 'North Dakota',
+    'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island',
+    'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont',
+    'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
+];
+
+var substringMatcher = function (strings) {
+    return function findMatches(query, callback) {
+        var matches;
+
+        // an array that will be populated with substring matches
+        matches = [];
+
+        // regex used to determine if a string contains the substring `q`
+        substrRegex = new RegExp(query, 'i');
+
+        // iterate through the pool of strings and for any string that
+        // contains the substring `q`, add it to the `matches` array
+        $.each(strings, function (i, str) {
+            if (substrRegex.test(str)) {
+                matches.push(str);
+            }
+        });
+
+        callback(matches);
+    };
+};
+
+
+var options = {};
+var dataSet = {
+    source: substringMatcher(states)
+};
+
+$('.typeahead').typeahead(options, dataSet);
+
+$('button.remove').click(
+    function () {
+        $('.typeahead').typeahead('val', '').trigger('typeahead:idle');
+    }
+);

--- a/examples/input-group.html
+++ b/examples/input-group.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../node_modules/typeahead.js/dist/typeahead.jquery.js"></script>
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css"/>
+    <link rel="stylesheet" href="../typeaheadjs.css"/>
+</head>
+
+<body>
+<div class="col-md-9 col-md-offset-1">
+    <h1>input-group input-group-addon</h1>
+    <div class="input-group">
+        <span class="input-group-addon">
+            <span class="glyphicon glyphicon-search"></span>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+    </div>
+
+    <h1>input-group-sm input-group-addon</h1>
+    <div class="input-group input-group-sm">
+        <span class="input-group-addon">
+            <span class="glyphicon glyphicon-search"></span>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+    </div>
+
+    <h1>input-group-lg input-group-addon</h1>
+    <div class="input-group input-group-lg">
+        <span class="input-group-addon">
+            <span class="glyphicon glyphicon-search"></span>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+    </div>
+
+    <h1>input-group input-group-button</h1>
+    <div class="input-group">
+        <span class="input-group-btn">
+            <button class="btn btn-default" type="button">
+                <span class="glyphicon glyphicon-search"></span>
+            </button>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+    </div>
+
+    <h1>input-group-sm input-group-button</h1>
+    <div class="input-group input-group-sm">
+        <span class="input-group-btn">
+            <button class="btn btn-default" type="button">
+                <span class="glyphicon glyphicon-search"></span>
+            </button>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+    </div>
+
+    <h1>input-group-lg input-group-button</h1>
+    <div class="input-group input-group-lg">
+        <span class="input-group-btn">
+            <button class="btn btn-default" type="button">
+                <span class="glyphicon glyphicon-search"></span>
+            </button>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+    </div>
+
+    <h1>input-group input-group-buttons</h1>
+    <div class="input-group">
+        <span class="input-group-btn">
+            <button class="btn btn-default" type="button">
+                <span class="glyphicon glyphicon-search"></span>
+            </button>
+            <button class="btn btn-default remove" type="button">
+                <span class="glyphicon glyphicon-remove"></span>
+            </button>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+    </div>
+
+    <h1>input-group-sm input-group-buttons</h1>
+    <div class="input-group input-group-sm">
+        <span class="input-group-btn">
+            <button class="btn btn-default" type="button">
+                <span class="glyphicon glyphicon-search"></span>
+            </button>
+            <button class="btn btn-default remove" type="button">
+                <span class="glyphicon glyphicon-remove"></span>
+            </button>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+    </div>
+
+    <h1>input-group-lg input-group-buttons</h1>
+    <div class="input-group input-group-lg">
+        <span class="input-group-btn">
+            <button class="btn btn-default" type="button">
+                <span class="glyphicon glyphicon-search"></span>
+            </button>
+            <button class="btn btn-default remove" type="button">
+                <span class="glyphicon glyphicon-remove"></span>
+            </button>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+    </div>
+
+    <h1>input-group input-group-addon input-group-button</h1>
+    <div class="input-group">
+        <span class="input-group-addon">
+            <span class="glyphicon glyphicon-search"></span>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+        <span class="input-group-btn">
+            <button class="btn btn-default remove" type="button">
+                <span class="glyphicon glyphicon-remove"></span>
+            </button>
+        </span>
+    </div>
+
+    <h1>input-group-sm input-group-addon input-group-button</h1>
+    <div class="input-group input-group-sm">
+        <span class="input-group-addon">
+            <span class="glyphicon glyphicon-search"></span>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+        <span class="input-group-btn">
+            <button class="btn btn-default remove" type="button">
+                <span class="glyphicon glyphicon-remove"></span>
+            </button>
+        </span>
+    </div>
+
+    <h1>input-group-lg input-group-addon input-group-button</h1>
+    <div class="input-group input-group-lg">
+        <span class="input-group-addon">
+            <span class="glyphicon glyphicon-search"></span>
+        </span>
+        <input type="text" class="form-control typeahead" placeholder="Search...">
+        <span class="input-group-btn">
+            <button class="btn btn-default remove" type="button">
+                <span class="glyphicon glyphicon-remove"></span>
+            </button>
+        </span>
+    </div>
+</div>
+
+<script src="initialize.js"></script>
+</body>
+</html>

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="../node_modules/typeahead.js/dist/typeahead.jquery.js"></script>
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css"/>
+    <link rel="stylesheet" href="../typeaheadjs.css"/>
+</head>
+
+<body>
+<div class="col-md-9 col-md-offset-1">
+    <h1>simple</h1>
+    <input type="text" class="form-control typeahead" placeholder="Search...">
+</div>
+
+<script src="initialize.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   "bugs": {
     "url": "https://github.com/bassjobsen/typeahead.js-bootstrap-css/issues"
   },
+  "devDependencies": {
+    "bootstrap": "~3.3",
+    "typeahead.js": "~0.11"
+  },
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
This shows some problems when combining input-group-sm / input-group-lg with add ons / buttons when activating typeahead functionality.